### PR TITLE
Feature/update deps 2026 04 18

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -43,25 +43,6 @@ jobs:
           environment_github: true
         run: composer all
 
-      - name: Debug workspace + coverage (8.4 only)
-        if: ${{ matrix.php-versions == '8.4' }}
-        run: |
-          echo "=== pwd ==="
-          pwd
-          echo "=== workspace root ls ==="
-          ls -la
-          echo "=== clover.xml at root? ==="
-          [ -f clover.xml ] && echo "yes, $(wc -c < clover.xml) bytes" || echo "NO"
-          echo "=== coverage-report tree (if present) ==="
-          [ -d coverage-report ] && find coverage-report -maxdepth 4 -type f | head -20 || echo "no coverage-report dir"
-          echo "=== PHP coverage drivers ==="
-          php -m | grep -iE 'pcov|xdebug' || echo "no pcov or xdebug loaded"
-          echo "=== phpunit version ==="
-          vendor/bin/phpunit --version
-          echo "=== direct phpunit clover check ==="
-          vendor/bin/phpunit --colors=never --coverage-clover debug-clover.xml 2>&1 | tail -20
-          [ -f debug-clover.xml ] && echo "debug-clover.xml created, $(wc -c < debug-clover.xml) bytes" || echo "debug-clover.xml NOT created"
-
       - name: Upload coverage to Codecov
         if: ${{ matrix.php-versions == '8.4' }}
         uses: codecov/codecov-action@v4

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -1,32 +1,20 @@
-name: GitHub_CI
+name: Tests [PHP7.1-8.5]
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master ]
   pull_request:
     branches: [ master, develop ]
 
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     runs-on: ${{ matrix.operating-system }}
-    services:
-      # Setup MYSQL
-      mysql-service:
-        image: mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: 'crab'
-          MYSQL_DATABASE: pc_core_tests
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -34,7 +22,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, intl
+          extensions: mbstring, intl, pcov
           ini-values: post_max_size=256M, log_errors=1
           tools: pecl
 
@@ -42,20 +30,23 @@ jobs:
         run: php -v
 
       - name: Clear existing composer
-        run: rm -rf wordpress && rm -rf vendor && rm -rf composer.lock 
+        run: rm -rf vendor composer.lock
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate
+      - name: Validate composer.json
+        run: composer validate --no-check-lock
 
       - name: Install dependencies
-        run: composer clearcache && rm -rf composer.lock && composer install --prefer-dist --no-suggest
+        run: composer clearcache && composer update --no-cache --prefer-dist
 
       - name: Run Tests
         env:
           environment_github: true
         run: composer all
 
-      - name: Codecov
-        run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_COLLECTION }}
-
-      
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.php-versions == '8.4' }}
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_COLLECTION }}
+          files: ./clover.xml
+          fail_ci_if_error: false

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -2,7 +2,7 @@ name: Tests [PHP7.1-8.5]
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
     branches: [ master, develop ]
 

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -43,6 +43,25 @@ jobs:
           environment_github: true
         run: composer all
 
+      - name: Debug workspace + coverage (8.4 only)
+        if: ${{ matrix.php-versions == '8.4' }}
+        run: |
+          echo "=== pwd ==="
+          pwd
+          echo "=== workspace root ls ==="
+          ls -la
+          echo "=== clover.xml at root? ==="
+          [ -f clover.xml ] && echo "yes, $(wc -c < clover.xml) bytes" || echo "NO"
+          echo "=== coverage-report tree (if present) ==="
+          [ -d coverage-report ] && find coverage-report -maxdepth 4 -type f | head -20 || echo "no coverage-report dir"
+          echo "=== PHP coverage drivers ==="
+          php -m | grep -iE 'pcov|xdebug' || echo "no pcov or xdebug loaded"
+          echo "=== phpunit version ==="
+          vendor/bin/phpunit --version
+          echo "=== direct phpunit clover check ==="
+          vendor/bin/phpunit --colors=never --coverage-clover debug-clover.xml 2>&1 | tail -20
+          [ -f debug-clover.xml ] && echo "debug-clover.xml created, $(wc -c < debug-clover.xml) bytes" || echo "debug-clover.xml NOT created"
+
       - name: Upload coverage to Codecov
         if: ${{ matrix.php-versions == '8.4' }}
         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ wordpress
 coverage-report
 composer.lock
 coverage.xml
+clover.xml
+.phpunit.result.cache
 .vscode

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,85 @@
+checks:
+    php:
+        code_rating: true
+        duplication: true
+        fix_php_opening_tag: false
+        remove_php_closing_tag: false
+        one_class_per_file: false
+        side_effects_or_types: false
+        no_mixed_inline_html: false
+        require_braces_around_control_structures: false
+        php5_style_constructor: false
+        no_global_keyword: false
+        avoid_usage_of_logical_operators: false
+        psr2_class_declaration: false
+        no_underscore_prefix_in_properties: false
+        no_underscore_prefix_in_methods: false
+        blank_line_after_namespace_declaration: false
+        single_namespace_per_use: false
+        psr2_switch_declaration: false
+        psr2_control_structure_declaration: false
+        avoid_superglobals: false
+        security_vulnerabilities: false
+        no_exit: false
+
+build:
+    dependencies:
+        override:
+            - 'composer install --no-interaction --prefer-dist'
+    nodes:
+        analysis:
+            project_setup:
+                override:
+                    - 'true'
+            tests:
+                override:
+                    - php-scrutinizer-run
+
+tools:
+    php_analyzer:
+        enabled: true
+        filter:
+            excluded_paths: ['tests/*', 'docs/*', 'template/*', 'node_modules/*', 'vendor/*']
+        config:
+            checkstyle:
+                enabled: true
+                naming:
+                    isser_method_name: ^.*$
+                    utility_class_name: ^.*$
+            doc_comment_fixes:
+                enabled: false
+            reflection_fixes:
+                enabled: false
+            use_statement_fixes:
+                enabled: false
+            simplify_boolean_return:
+                enabled: true
+    php_changetracking: true
+    php_cpd: true
+    php_cs_fixer: false
+    php_mess_detector: true
+    php_pdepend: true
+    sensiolabs_security_checker: true
+
+filter:
+    paths:
+        - 'src/*'
+    excluded_paths:
+        - 'tests/*'
+        - 'docs/*'
+        - 'docs-gen/*'
+        - 'node_modules/*'
+        - 'vendor/*'
+        - 'template/*'
+
+coding_style:
+    php:
+        indentation:
+            general:
+                use_tabs: true
+                size: 4
+        spaces:
+            before_parentheses:
+                closure_definition: true
+            around_operators:
+                concatenation: true

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # PinkCrab Collection #
 
-![alt text](https://img.shields.io/badge/Current_Version-0.2.0-yellow.svg?style=flat " ") 
-[![Open Source Love](https://badges.frapsoft.com/os/mit/mit.svg?v=102)]()
-![](https://github.com/Pink-Crab/Collection/workflows/GitHub_CI/badge.svg " ")
-[![codecov](https://codecov.io/gh/Pink-Crab/collection/branch/master/graph/badge.svg?token=6tUeia2v2S)](https://codecov.io/gh/Pink-Crab/collection)
+[![Latest Stable Version](https://poser.pugx.org/pinkcrab/collection/v)](https://packagist.org/packages/pinkcrab/collection)
+[![Total Downloads](https://poser.pugx.org/pinkcrab/collection/downloads)](https://packagist.org/packages/pinkcrab/collection)
+[![License](https://poser.pugx.org/pinkcrab/collection/license)](https://packagist.org/packages/pinkcrab/collection)
+[![PHP Version Require](https://poser.pugx.org/pinkcrab/collection/require/php)](https://packagist.org/packages/pinkcrab/collection)
+![GitHub contributors](https://img.shields.io/github/contributors/Pink-Crab/Collection?label=Contributors)
+![GitHub issues](https://img.shields.io/github/issues-raw/Pink-Crab/Collection)
 
-## Version 0.2.0 ##
+[![Tests [PHP7.1-8.5]](https://github.com/Pink-Crab/Collection/actions/workflows/php.yaml/badge.svg)](https://github.com/Pink-Crab/Collection/actions/workflows/php.yaml)
+
+[![codecov](https://codecov.io/gh/Pink-Crab/collection/branch/master/graph/badge.svg?token=6tUeia2v2S)](https://codecov.io/gh/Pink-Crab/collection)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Pink-Crab/Collection/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Pink-Crab/Collection/?branch=master)
+
+## Version 1.0.0 ##
 
 > This library was extracted from the PinkCrab Plugin Framework (Perique)
 
@@ -15,7 +22,17 @@ Give access to a basic collection with all expected functionlaity, filtering, ma
 
 ## Install ##
 
-> `composer install pink-crab/collection`
+Install via Composer:
+
+```bash
+composer require pinkcrab/collection
+```
+
+Then include the Composer autoloader in your project:
+
+```php
+require_once __DIR__ . '/vendor/autoload.php';
+```
 
 ## Basic Useage ##
 
@@ -88,6 +105,7 @@ $collection->each(function($e){
 #### MIT License http://www.opensource.org/licenses/mit-license.html  
 
 ## Change Log ##
+* 1.0.0 - Raised supported PHP range to 7.1–8.5 and modernised the tooling chain (PHPStan 2.x + phpstan stubs so traits are actually analysed, PHPUnit up to 9.6, WPCS-based phpcs). Interface implementations (`ArrayAccess`, `Iterator`, `JsonSerializable`) marked with `#[\ReturnTypeWillChange]` for PHP 8.1+ without dropping PHP 7.x support. `Sequence::sum()` now filters non-numeric values to stay compatible with PHP 8.3's stricter `array_sum()`. Corrected phpdoc types on `Has_ArrayAccess::offsetSet` (nullable offset) and `Is_Iterable::key` (nullable return). **BC break:** public method parameters renamed `$function`/`$callable` → `$callback` on `apply()`, `each()`, `filter()`, `map()`, `reduce()`, `sort()`, `sorted()`, `group_by()` — positional callers unaffected, named-argument callers need to update.
 * 0.2.0 - Added in option callbacks for diff and intersect, complete with helper functions for checking based on object instance or values/type. Also includes the group_by() method.
 * 0.1.0 - Added Has_ArrayAccess and Is_Iterable traits to allow the implementation of the interfaces. Added docs from existing GitBook repo.
 * 0.0.0 - Extracted from the PinkCrab Plugin Framework as a standalone package.

--- a/composer.json
+++ b/composer.json
@@ -23,22 +23,25 @@
         "files": []
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
-        "symfony/var-dumper": "4.*",
-        "phpstan/phpstan": "^0.12.6",
+        "phpunit/phpunit": "<=9.6",
+        "phpstan/phpstan": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "wp-coding-standards/wpcs": "*",
-        "object-calisthenics/phpcs-calisthenics-rules": "*",
-        "gin0115/wpunit-helpers": "^1.0"
+        "symfony/var-dumper": "*"
     },
     "require": {
         "php": ">=7.1.0"
     },
     "scripts": {
-        "test": "phpunit --coverage-clover coverage.xml --testdox",
-        "coverage": "phpunit --coverage-html coverage-report --testdox",
-        "analyse": "vendor/bin/phpstan analyse src -l8",
+        "test": "vendor/bin/phpunit --colors=always --testdox --coverage-clover clover.xml",
+        "coverage": "vendor/bin/phpunit --colors=always --testdox --coverage-html coverage-report --coverage-clover clover.xml",
+        "analyse": "vendor/bin/phpstan analyse -l8",
         "sniff": "./vendor/bin/phpcs src/ -v",
-        "all": "composer test && composer analyse && composer sniff"
+        "all": "composer coverage && composer analyse && composer sniff"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "coverage": "vendor/bin/phpunit --colors=always --testdox --coverage-html coverage-report --coverage-clover clover.xml",
         "analyse": "vendor/bin/phpstan analyse -l8",
         "sniff": "./vendor/bin/phpcs src/ -v",
-        "all": "composer coverage && composer analyse && composer sniff"
+        "all": "composer test && composer analyse && composer sniff"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "files": []
     },
     "require-dev": {
-        "phpunit/phpunit": "<=9.6",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
         "phpstan/phpstan": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "wp-coding-standards/wpcs": "*",

--- a/docs/Collection.md
+++ b/docs/Collection.md
@@ -31,7 +31,7 @@ $collection = Collection::from(['your','data']);
 
 A callback can be applied to every element in the collection. This works like map\(\), but rather than returning a new Collection, apply is just applied to the current data.
 
-> @param callable $function  
+> @param callable $callback  
 >       function\(mixed $value\): mixed {...}  
 > @return Existing Collection
 
@@ -47,7 +47,7 @@ var_dump($collection); // 2,4,6,8
 
 A callback can be applied to all items in a collection, then a new collection is returned with the new values. If the Collection is extended, it will return a new instance of the extended class. 
 
-> @param callable $function  
+> @param callable $callback  
 >       function\(mixed $value\): mixed {...}  
 > @return New Collection
 
@@ -63,7 +63,7 @@ var_dump($new_collection); // 2,4,6,8
 
 A callback can be used to perform a foreach loop of the data. The callback takes both $value and $key and a return value is not required/ignored.
 
-> @param callable $function  
+> @param callable $callback  
 >       function\(mixed $value, int\|string $key\): void {...}  
 > @return Existing Collection
 
@@ -83,7 +83,7 @@ C is for Cat
 
 The collection can be filtered into a new collection. It uses the regular array\_filter under the hood and allows the use of its additional flags.
 
-> @param callable $function  
+> @param callable $callback  
 >       function\(mixed $value\|value \[, int\|string $key\], int $mode = 0\): bool {...}  
 > @return New Collection
 
@@ -127,7 +127,7 @@ Applies a filter to reduce the contents of the collection to a single value. Use
 
 By default, the initial value is an empty string, but this can be set as the send parameter.
 
-> @param callable $function  
+> @param callable $callback  
 >       function\(mixed $carry, mixed $value\): mixed {...}  
 > @param mixed $inital  
 > @return Existing Collection
@@ -291,7 +291,7 @@ var_dump($collection === $copy_collection); //false
 
 Sorts the internal array using either natsort\(\) or usort\(\). The same instance is returned after sorting, if you wish to create a new instance, see sorted\(\)
 
-@param callable\|null $function   
+@param callable\|null $callback   
 @return Existing Collection
 
 ```php
@@ -314,7 +314,7 @@ var_dump($collection); // z,y,o,f,a
 
 Sorts the contents of the collection using sort\(\) above, but returns a new collection instance.
 
-@param callable\|null $function   
+@param callable\|null $callback   
 @return New Collection
 
 ```php
@@ -404,7 +404,7 @@ $collection->intersect($some_array, Comparisons::by_values());
 
 Groups an existing collection into sub collections (of the same type), which itself in held in a `Collection` that uses the `Indexed` trait.
 
-> @param callable $callable  
+> @param callable $callback  
 > @return New Indexed Collection  
 
 ```php

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -19,6 +19,7 @@
 		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_close"/>
 		<exclude name="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents"/>
 		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
+		<exclude name="PSR12.Files.FileHeader.IncorrectOrder" />
 	</rule>
 
 	<!-- Add in some extra rules from other standards. -->

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,12 +1,8 @@
-# Start command: composer update --classmap-authoritative && vendor/bin/phpstan analyze
-
-includes:
-    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
 parameters:
     level: max
     inferPrivatePropertyTypeFromConstructor: true
     paths:
         - %currentWorkingDirectory%/src/
-    excludes_analyse:
+        - %currentWorkingDirectory%/stubs/
+    excludePaths:
         - %currentWorkingDirectory%/tests/*
-    bootstrapFiles:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,4 +18,8 @@
             <directory suffix=".php">./src/</directory>
         </include>
     </coverage>
+
+    <logging>
+        <log type="coverage-clover" target="clover.xml"/>
+    </logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,6 @@
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     executionOrder="random"
-    
     >
     <testsuites>
         <testsuite name="core">
@@ -14,13 +13,9 @@
         </testsuite>
     </testsuites>
 
-     <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log type="coverage-clover" target="coverage-report/logs/clover.xml"/>
-    </logging>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -74,12 +74,12 @@ class Collection implements Countable {
 	/**
 	 * Apply a function to the collection of items.
 	 *
-	 * @param callable $function
+	 * @param callable $callback
 	 * @return self
 	 */
-	public function apply( callable $function ): self {
+	public function apply( callable $callback ): self {
 		foreach ( $this->data as &$element ) {
-			$element = $function( $element );
+			$element = $callback( $element );
 		}
 		return $this;
 	}
@@ -87,12 +87,12 @@ class Collection implements Countable {
 	/**
 	 * Apply a function to the collection of items.
 	 *
-	 * @param callable $function
+	 * @param callable $callback
 	 * @return self
 	 */
-	public function each( callable $function ): self {
+	public function each( callable $callback ): self {
 		foreach ( $this->data as $key => $value ) {
-			$function( $value, $key );
+			$callback( $value, $key );
 		}
 		return $this;
 	}
@@ -100,35 +100,35 @@ class Collection implements Countable {
 	/**
 	 * Apply a filter function to the contents.
 	 *
-	 * @param callable $function
+	 * @param callable $callback
 	 * @return self
 	 */
-	public function filter( callable $function, int $mode = 0 ): self {
-		return new static( array_filter( $this->data, $function, $mode ) );
+	public function filter( callable $callback, int $mode = 0 ): self {
+		return new static( array_filter( $this->data, $callback, $mode ) );
 	}
 
 	/**
 	 * Apply a map function to the contents.
 	 *
-	 * @param callable $function
+	 * @param callable $callback
 	 * @return self
 	 */
-	public function map( callable $function ): self {
-		return new static( array_map( $function, $this->data ) );
+	public function map( callable $callback ): self {
+		return new static( array_map( $callback, $this->data ) );
 	}
 
 	/**
 	 * Apply a function to reduce the contents of the internal array.
 	 *
-	 * @param callable $function
+	 * @param callable $callback
 	 * @param string $inital
 	 * @return mixed
 	 */
-	public function reduce( callable $function, $inital = '' ) {
+	public function reduce( callable $callback, $inital = '' ) {
 		return array_reduce(
 			$this->data,
-			function( $carry, $value ) use ( $function ) {
-				return $function( $carry, $value );
+			function ( $carry, $value ) use ( $callback ) {
+				return $callback( $carry, $value );
 			},
 			$inital
 		);
@@ -138,19 +138,17 @@ class Collection implements Countable {
 	 * Merges with another array or collection
 	 *
 	 * @param Collection|array<int|string, mixed> $data
+	 * @phpstan-param mixed $data
 	 * @return self
 	 * @throws TypeError If not an arrya or Collection.
 	 */
 	public function merge( $data ): self {
-		if ( ! is_array( $data ) && ! is_a( $data, static::class ) ) {
+		if ( $data instanceof self ) {
+			$data = $data->to_array();
+		} elseif ( ! is_array( $data ) ) {
 			throw new TypeError( 'Can only merge with other Collections or Arrays.' );
 		}
-		return new static(
-			array_merge(
-				$this->data,
-				is_object( $data ) && is_a( $data, static::class ) ? $data->to_array() : $data
-			)
-		);
+		return new static( array_merge( $this->data, $data ) );
 	}
 
 	/**
@@ -280,12 +278,12 @@ class Collection implements Countable {
 	/**
 	 * Sorts the existing collection and returns the current instance.
 	 *
-	 * @param callable|null $function
+	 * @param callable|null $callback
 	 * @return self
 	 */
-	public function sort( ?callable $function = null ): self {
-		if ( $function ) {
-			usort( $this->data, $function );
+	public function sort( ?callable $callback = null ): self {
+		if ( $callback ) {
+			usort( $this->data, $callback );
 		} else {
 			natsort( $this->data );
 		}
@@ -296,11 +294,11 @@ class Collection implements Countable {
 	/**
 	 * Sorts a new instance of the collection.
 	 *
-	 * @param callable|null $function
+	 * @param callable|null $callback
 	 * @return self
 	 */
-	public function sorted( ?callable $function = null ): self {
-		return ( new static( $this->data ) )->sort( $function );
+	public function sorted( ?callable $callback = null ): self {
+		return ( new static( $this->data ) )->sort( $callback );
 	}
 
 	/**
@@ -321,17 +319,18 @@ class Collection implements Countable {
 	 * objects. If no $comparator function passed, will match objects by instance (not values.)
 	 *
 	 * @param array<int|string, mixed>|Collection $comparison_data
+	 * @phpstan-param mixed $comparison_data
 	 * @param callable|null $comparator The Comparison function to use.
 	 * @return self
 	 * @throws TypeError
 	 */
-	public function diff( $comparison_data, ?callable $comparator = null ):self {
+	public function diff( $comparison_data, ?callable $comparator = null ): self {
 
-		if ( ! is_array( $comparison_data ) && ! is_a( $comparison_data, static::class ) ) {
+		if ( $comparison_data instanceof self ) {
+			$comparison_data = $comparison_data->to_array();
+		} elseif ( ! is_array( $comparison_data ) ) {
 			throw new \TypeError( 'Can only find the diff with other Collections or Arrays.' );
 		}
-
-		$comparison_data = is_object( $comparison_data ) && is_a( $comparison_data, static::class ) ? $comparison_data->to_array() : $comparison_data;
 
 		$new_data = Comparisons::contains_object( $this->data ) || Comparisons::contains_object( $comparison_data )
 			? \array_udiff( $this->data, $comparison_data, $comparator ?? Comparisons::by_instances() )
@@ -347,17 +346,18 @@ class Collection implements Countable {
 	 * objects. If no $comparator function passed, will match objects by instance (not values.)
 	 *
 	 * @param array<int|string, mixed>|Collection $comparison_data
+	 * @phpstan-param mixed $comparison_data
 	 * @param callable|null $comparator The Comparison function to use.
 	 * @return self
 	 * @throws TypeError
 	 */
-	public function intersect( $comparison_data, ?callable $comparator = null ):self {
+	public function intersect( $comparison_data, ?callable $comparator = null ): self {
 
-		if ( ! is_array( $comparison_data ) && ! is_a( $comparison_data, static::class ) ) {
+		if ( $comparison_data instanceof self ) {
+			$comparison_data = $comparison_data->to_array();
+		} elseif ( ! is_array( $comparison_data ) ) {
 			throw new \TypeError( 'Can only intersection with other Collections or Arrays.' );
 		}
-
-		$comparison_data = is_object( $comparison_data ) && is_a( $comparison_data, static::class ) ? $comparison_data->to_array() : $comparison_data;
 
 		$new_data = Comparisons::contains_object( $this->data ) || Comparisons::contains_object( $comparison_data )
 			? \array_uintersect( $this->data, $comparison_data, $comparator ?? Comparisons::by_instances() )
@@ -369,11 +369,11 @@ class Collection implements Countable {
 	/**
 	 * Creates an indexed collection of all values using the callable passed
 	 *
-	 * @param callable $callable
+	 * @param callable $callback
 	 * @return self
 	 * @since 0.2.0
 	 */
-	public function group_by( callable $callable ):self {
+	public function group_by( callable $callback ): self {
 		$group = array();
 
 		$new_collection = new class() extends Collection{
@@ -382,7 +382,7 @@ class Collection implements Countable {
 
 		// Group the data using callable
 		foreach ( $this->data as $value ) {
-			$result             = $callable( $value );
+			$result             = $callback( $value );
 			$group[ $result ][] = $value;
 		}
 
@@ -393,5 +393,4 @@ class Collection implements Countable {
 
 		return $new_collection;
 	}
-
 }

--- a/src/Helpers/Comparisons.php
+++ b/src/Helpers/Comparisons.php
@@ -32,7 +32,7 @@ class Comparisons {
 	 * Returns the for_object_values as lambda.
 	 *
 	 * @since 0.2.0
-	 * @return callable(mixed:$a,mixed:$b): int
+	 * @return callable(mixed, mixed): int
 	 */
 	public static function by_values(): callable {
 		/**
@@ -40,7 +40,7 @@ class Comparisons {
 		 * @param mixed $b
 		 * @return int
 		 */
-		return function( $a, $b ): int {
+		return function ( $a, $b ): int {
 			return ( new self() )->for_object_values( $a, $b );
 		};
 	}
@@ -49,7 +49,7 @@ class Comparisons {
 	 * Returns the for_object_instances as lambda.
 	 *
 	 * @since 0.2.0
-	 * @return callable(mixed:$a,mixed:$b): int
+	 * @return callable(mixed, mixed): int
 	 */
 	public static function by_instances(): callable {
 		/**
@@ -57,7 +57,7 @@ class Comparisons {
 		 * @param mixed $b
 		 * @return int
 		 */
-		return function( $a, $b ): int {
+		return function ( $a, $b ): int {
 			return ( new self() )->for_object_instances( $a, $b );
 		};
 	}
@@ -96,7 +96,7 @@ class Comparisons {
 		}
 
 		if ( \is_object( $a ) && \is_object( $b ) ) {
-			return $a == $b ? 0 : -1; // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+			return $a == $b ? 0 : -1; // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison,Universal.Operators.StrictComparisons.LooseEqual
 		}
 
 		if ( is_bool( $a ) || is_bool( $b ) ) {
@@ -126,11 +126,11 @@ class Comparisons {
 			return \spl_object_hash( $a ) > \spl_object_hash( $b ) ? 1 : -1;
 		}
 
-		if ( \is_object( $a ) && ! \is_object( $b ) ) { // @phpstan-ignore-line
+		if ( \is_object( $a ) ) {
 			return 1;
 		}
 
-		if ( \is_object( $b ) && ! \is_object( $a ) ) {
+		if ( \is_object( $b ) ) {
 			return -1;
 		}
 

--- a/src/Traits/Has_ArrayAccess.php
+++ b/src/Traits/Has_ArrayAccess.php
@@ -30,10 +30,14 @@ trait Has_ArrayAccess {
 	/**
 	 * Sets a value based on the offset passed.
 	 *
-	 * @param string|int $offset
+	 * A null offset means `$collection[] = $value` — append semantics per
+	 * the ArrayAccess contract.
+	 *
+	 * @param string|int|null $offset
 	 * @param mixed $value
 	 * @return void
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 
 		if ( is_null( $offset ) ) {
@@ -49,6 +53,7 @@ trait Has_ArrayAccess {
 	 * @param string|int $offset
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		return isset( $this->data[ $offset ] );
 	}
@@ -59,6 +64,7 @@ trait Has_ArrayAccess {
 	 * @param string|int $offset
 	 * @return void
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {
 		unset( $this->data[ $offset ] );
 	}
@@ -69,6 +75,7 @@ trait Has_ArrayAccess {
 	 * @param string|int $offset
 	 * @return mixed|null
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		return isset( $this->data[ $offset ] ) ? $this->data[ $offset ] : null;
 	}

--- a/src/Traits/Indexed.php
+++ b/src/Traits/Indexed.php
@@ -85,7 +85,8 @@ trait Indexed {
 	 */
 	public function remove( $index ) {
 		if ( ! array_key_exists( $index, $this->data ) ) {
-			throw new OutOfRangeException( sprintf( '%d index doesnt exist in %s', $index, get_class() ) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- exception message, not echoed.
+			throw new OutOfRangeException( sprintf( '%d index doesnt exist in %s', $index, static::class ) );
 		}
 
 		// Get the value, unset and return the value.

--- a/src/Traits/Is_Iterable.php
+++ b/src/Traits/Is_Iterable.php
@@ -31,6 +31,7 @@ trait Is_Iterable {
 	 *
 	 * @return mixed|null
 	 */
+	#[\ReturnTypeWillChange]
 	public function rewind() {
 		return reset( $this->data );
 	}
@@ -40,6 +41,7 @@ trait Is_Iterable {
 	 *
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function current() {
 		return current( $this->data );
 	}
@@ -47,8 +49,11 @@ trait Is_Iterable {
 	/**
 	 * Returns the current element key
 	 *
-	 * @return string|int
+	 * Returns null when the internal pointer is past the end of the array.
+	 *
+	 * @return string|int|null
 	 */
+	#[\ReturnTypeWillChange]
 	public function key() {
 		return key( $this->data );
 	}
@@ -58,6 +63,7 @@ trait Is_Iterable {
 	 *
 	 * @return mixed|false
 	 */
+	#[\ReturnTypeWillChange]
 	public function next() {
 		return next( $this->data );
 	}
@@ -67,6 +73,7 @@ trait Is_Iterable {
 	 *
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function valid() {
 		return key( $this->data ) !== null;
 	}

--- a/src/Traits/Is_JsonSerializable.php
+++ b/src/Traits/Is_JsonSerializable.php
@@ -33,10 +33,17 @@ trait Is_JsonSerializable {
 	 * Returns a representation that can be natively converted to JSON, which is
 	 * called when invoking json_encode.
 	 *
+	 * JsonSerializable::jsonSerialize() was declared `: mixed` in PHP 8.1.
+	 * Since this library still supports PHP 7.1 we can't add the return type
+	 * directly, so the ReturnTypeWillChange attribute silences the deprecation
+	 * on PHP 8.1+. On PHP 7.x the attribute syntax is parsed as a comment and
+	 * has no effect.
+	 *
 	 * @return mixed
 	 *
 	 * @see \JsonSerializable
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return $this->data;
 	}

--- a/src/Traits/Sequence.php
+++ b/src/Traits/Sequence.php
@@ -98,9 +98,14 @@ trait Sequence {
 	/**
 	 * Returns a sum of all the elements.
 	 *
+	 * Non-numeric entries are filtered out before summing. PHP 8.3 changed
+	 * array_sum() to throw a TypeError on non-numeric strings instead of
+	 * silently skipping them; filtering up front keeps the same "ignore
+	 * non-numeric values" semantics across every supported PHP version.
+	 *
 	 * @return int|float
 	 */
 	public function sum() {
-		return array_sum( $this->data );
+		return array_sum( array_filter( $this->data, 'is_numeric' ) );
 	}
 }

--- a/stubs/trait_usage.php
+++ b/stubs/trait_usage.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Trait usage stub for PHPStan.
+ *
+ * This class exists solely to give PHPStan a using-class context for the
+ * trait files in src/Traits/. Without a class applying each trait, PHPStan
+ * reports `trait.unused` and skips analysis of the trait body entirely,
+ * which masks real type errors inside the trait.
+ *
+ * Not autoloaded at runtime (no composer autoload entry) — analysis only.
+ *
+ * @package PinkCrab\Collection
+ */
+
+namespace PinkCrab\Collection\Stubs;
+
+use PinkCrab\Collection\Collection;
+use PinkCrab\Collection\Traits\Has_ArrayAccess;
+use PinkCrab\Collection\Traits\Is_Iterable;
+use PinkCrab\Collection\Traits\Is_JsonSerializable;
+use PinkCrab\Collection\Traits\Sequence;
+
+/**
+ * @implements \ArrayAccess<int|string, mixed>
+ * @implements \Iterator<int|string, mixed>
+ */
+class Stub_All_Traits extends Collection implements \ArrayAccess, \Iterator, \JsonSerializable {
+	use Has_ArrayAccess;
+	use Is_Iterable;
+	use Is_JsonSerializable;
+	use Sequence;
+}

--- a/tests/Fixtures/Type_A.php
+++ b/tests/Fixtures/Type_A.php
@@ -13,4 +13,7 @@ declare(strict_types=1);
 
 namespace PinkCrab\Collection\Tests\Fixtures;
 
-class Type_A {}
+class Type_A {
+	/** @var mixed */
+	public $value;
+}

--- a/tests/Fixtures/Type_B.php
+++ b/tests/Fixtures/Type_B.php
@@ -13,4 +13,7 @@ declare(strict_types=1);
 
 namespace PinkCrab\Collection\Tests\Fixtures;
 
-class Type_B {}
+class Type_B {
+	/** @var mixed */
+	public $value;
+}


### PR DESCRIPTION
This pull request modernizes the PinkCrab Collection library by updating its PHP compatibility, development tooling, and code style, while also introducing a minor breaking change to method parameter names for improved clarity. The changes ensure the library supports PHP 7.1 through 8.5, updates dependencies and CI workflows, and standardizes the use of `$callback` as a parameter name in public methods, which may affect users relying on named arguments.

**Key changes include:**

### PHP Compatibility & Tooling Modernization

- **Raised supported PHP versions to 7.1–8.5 and updated dev tooling:** The library now officially supports PHP 7.1 through 8.5, and the development dependencies have been updated to use PHPStan 2.x, PHPUnit up to 9.6, and WPCS-based phpcs. The CI workflow (`php.yaml`) was updated to test across all supported PHP versions and improved coverage reporting. [[1]](diffhunk://#diff-7e135120a7556f109b261e70c4fe73253de511e573f6ff7b9f11982966fca032L1-R52) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L26-R45) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108)
- **Added and updated static analysis and code quality tools:** Introduced `.scrutinizer.yml` for Scrutinizer integration, improved PHPStan configuration, and enhanced code analysis and coverage workflows. [[1]](diffhunk://#diff-e33be697c272a0b4b59c31c1f38bb7262446d4c649495555d58f1ebc214ae364R1-R85) [[2]](diffhunk://#diff-6f19df6a6307a48db0940e6897591fb08776d2db8a6134737aa708defdb5c92dL1-L12) [[3]](diffhunk://#diff-daa856500eea114bbf034fd35b7600050d965e5d19bb0700885c075747848fd8R22)

### Breaking Change: Method Parameter Renaming

- **Renamed function parameters to `$callback` in public methods:** All public methods that previously accepted a `$function` or `$callable` parameter now use `$callback` for clarity and consistency. This is a breaking change for users who call these methods with named arguments. [[1]](diffhunk://#diff-c0ffd81c6ca089efe31df824b65e2a235fca84c4b3b32721ab43dccef1e28e98L77-R131) [[2]](diffhunk://#diff-c0ffd81c6ca089efe31df824b65e2a235fca84c4b3b32721ab43dccef1e28e98L283-R286) [[3]](diffhunk://#diff-c0ffd81c6ca089efe31df824b65e2a235fca84c4b3b32721ab43dccef1e28e98L299-R301) [[4]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L34-R34) [[5]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L50-R50) [[6]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L66-R66) [[7]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L86-R86) [[8]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L130-R130) [[9]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L294-R294) [[10]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L317-R317) [[11]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L407-R407)

### Documentation & Readme Updates

- **Updated documentation and README for new version and usage:** The README now reflects version 1.0.0, updated installation instructions, new badges, and a detailed changelog highlighting the PHP version bump, tooling changes, and the breaking change to method parameters. Documentation was updated to use `$callback` in all relevant code examples and docblocks. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R35) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108) [[4]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L34-R34) [[5]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L50-R50) [[6]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L66-R66) [[7]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L86-R86) [[8]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L130-R130) [[9]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L294-R294) [[10]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L317-R317) [[11]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L407-R407)

### Internal Code Improvements

- **Improved `merge` and `diff` methods for type safety and clarity:** These methods now explicitly handle merging and diffing with either arrays or other `Collection` instances, improving type safety and code simplicity. [[1]](diffhunk://#diff-c0ffd81c6ca089efe31df824b65e2a235fca84c4b3b32721ab43dccef1e28e98R141-R151) [[2]](diffhunk://#diff-c0ffd81c6ca089efe31df824b65e2a235fca84c4b3b32721ab43dccef1e28e98R322-L335)

---

**References:**  
[[1]](diffhunk://#diff-7e135120a7556f109b261e70c4fe73253de511e573f6ff7b9f11982966fca032L1-R52) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L26-R45) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108) [[4]](diffhunk://#diff-e33be697c272a0b4b59c31c1f38bb7262446d4c649495555d58f1ebc214ae364R1-R85) [[5]](diffhunk://#diff-6f19df6a6307a48db0940e6897591fb08776d2db8a6134737aa708defdb5c92dL1-L12) [[6]](diffhunk://#diff-daa856500eea114bbf034fd35b7600050d965e5d19bb0700885c075747848fd8R22) [[7]](diffhunk://#diff-c0ffd81c6ca089efe31df824b65e2a235fca84c4b3b32721ab43dccef1e28e98L77-R131) [[8]](diffhunk://#diff-c0ffd81c6ca089efe31df824b65e2a235fca84c4b3b32721ab43dccef1e28e98L283-R286) [[9]](diffhunk://#diff-c0ffd81c6ca089efe31df824b65e2a235fca84c4b3b32721ab43dccef1e28e98L299-R301) [[10]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L34-R34) [[11]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L50-R50) [[12]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L66-R66) [[13]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L86-R86) [[14]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L130-R130) [[15]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L294-R294) [[16]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L317-R317) [[17]](diffhunk://#diff-f6875c8a038ae7fb1f747def7409f59b3a5d9e86ed50065751f27430cf1ab0f7L407-R407) [[18]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R15) [[19]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R35) [[20]](diffhunk://#diff-c0ffd81c6ca089efe31df824b65e2a235fca84c4b3b32721ab43dccef1e28e98R141-R151) [[21]](diffhunk://#diff-c0ffd81c6ca089efe31df824b65e2a235fca84c4b3b32721ab43dccef1e28e98R322-L335)