### PR TITLE
chore(docs): normalise code-block indentation from tabs to 4 spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The Collection package comes with a few Traits which can be used when creating c
 
 ```php
 $indexed_collection = new class() extends \PinkCrab\Collection\Collection {
-	use \PinkCrab\Collection\Traits\Indexed;
+    use \PinkCrab\Collection\Traits\Indexed;
 };
 
 $indexed_collection->set( 'key1', 'value1' );
@@ -67,7 +67,7 @@ var_dump( $indexed_collection );
 
 // As a full class.
 class Indexed_Collection extends \PinkCrab\Collection\Collection {
-	use \PinkCrab\Collection\Traits\Indexed;
+    use \PinkCrab\Collection\Traits\Indexed;
 };
 
 $indexed_collection = new Indexed_Collection();
@@ -83,17 +83,17 @@ var_dump( $indexed_collection );
 <?php
 
 class Post_Collection extends Collection {
-	// Filter out anything not matching.
-	protected function map_construct( array $data ): array {
-		return array_filter(fn($e): bool => is_a($data, \WP_Post::class));
-	}
+    // Filter out anything not matching.
+    protected function map_construct( array $data ): array {
+        return array_filter(fn($e): bool => is_a($data, \WP_Post::class));
+    }
 }
 
 $posts = Post_Collection::from([$post1, null, $post2, false, WP_Error]);
 var_dump($posts->to_array()); // [$post1, $post2];
 
 $collection->each(function($e){
-	print $e->post_title . PHP_EOL;
+    print $e->post_title . PHP_EOL;
 }); 
 // Post Title 1
 // Post Title 2

--- a/docs/Collection.md
+++ b/docs/Collection.md
@@ -90,13 +90,13 @@ The collection can be filtered into a new collection. It uses the regular array\
 ```php
 $initial_collection = Collection::from([1,2,3,4,5,6,7,8]);
 $filtered_collection = $initial_collection->filter(function( $e ) {
-	return $e % 2 === 0;
+    return $e % 2 === 0;
 });
 var_dump($filtered_collection); // 2, 4, 6, 8
 
 // Using both flag.
 $with_both = $initial_collection->filter(function( $value, $key ) {
-	return $key % 2 === 0;
+    return $key % 2 === 0;
 }, ARRAY_FILTER_USE_BOTH);
 var_dump($with_both); // 1, 3, 5, 7
 
@@ -135,8 +135,8 @@ By default, the initial value is an empty string, but this can be set as the sen
 ```php
 $collection = Collection::from([1,2,3,4]);
 echo $collection->reduce(function($carry, $value){
-		$carry .= ( $value * 2 );
-		return $carry;
+        $carry .= ( $value * 2 );
+        return $carry;
 }, ''); // 2468
 ```
 
@@ -305,7 +305,7 @@ var_dump($collection); // a, f, o, y, z
 $collection->sort(
   function( $a, $b ) {
      return $b <=> $a;
-	}
+    }
 );
 var_dump($collection); // z,y,o,f,a
 ```

--- a/docs/traits/trait-has_arrayaccess.md
+++ b/docs/traits/trait-has_arrayaccess.md
@@ -15,7 +15,7 @@ use PinkCrab\Collection\Collection;
 use PinkCrab\Collection\Traits\Has_ArrayAccess;
 
 class Array_Collection extends Collection implements ArrayAccess {
-	use Has_ArrayAccess;
+    use Has_ArrayAccess;
 }
 ```
 

--- a/docs/traits/trait-indexed.md
+++ b/docs/traits/trait-indexed.md
@@ -19,7 +19,7 @@ use PinkCrab\Collection\Traits\Indexed;
  * Custom class which uses the Indexed trait
  */
 class Indexed_Collection extends Collection {
-	use Indexed;
+    use Indexed;
 }
 ```
 
@@ -92,7 +92,7 @@ dump($collection->find(3)); // false
 // With objects. 
 
 $obj_a = new class(){
-	public $property = 'value';
+    public $property = 'value';
 };
 $obj_b = (object) array( 'property' => 'value' );
 
@@ -102,7 +102,7 @@ $obj_collection = new Indexed_Collection([
     'c' => $obj_a,
 ]);
 dump($collection->find($obj_a)); // 'a'
-dump($collection->find(new class(){	public $property = 'value';})); // false
+dump($collection->find(new class(){    public $property = 'value';})); // false
 ```
 
 ### Indexed::remove\(\)

--- a/docs/traits/trait-is_iterable.md
+++ b/docs/traits/trait-is_iterable.md
@@ -15,7 +15,7 @@ use PinkCrab\Collection\Collection;
 use PinkCrab\Collection\Traits\Is_Iterable;
 
 class Iterable_Collection extends Collection implements Iterator {
-	use Is_Iterable;
+    use Is_Iterable;
 }
 ```
 

--- a/docs/traits/trait-jsonserializable.md
+++ b/docs/traits/trait-jsonserializable.md
@@ -16,7 +16,7 @@ use PinkCrab\Collection\Collection;
 use PinkCrab\Collection\Traits\Is_JsonSerializable;
 
 class Json_Serializeable_Collection extends Collection implements JsonSerializable {
-	use Is_JsonSerializable;
+    use Is_JsonSerializable;
 }
 ```
 

--- a/docs/traits/trait-sequence.md
+++ b/docs/traits/trait-sequence.md
@@ -18,7 +18,7 @@ use PinkCrab\Collection\Traits\Sequence;
  * Custom class which uses the Sequence trait
  */
 class Sequence_Collection extends Collection {
-	use Sequence;
+    use Sequence;
 }
 ```
 


### PR DESCRIPTION
Tabs in fenced markdown code blocks render at the browser default 8-column tab-stop on the docs site. Normalised to 4 spaces for consistent rendering. Source PHP files keep tabs (project/WP convention) — this is a docs-only normalisation.

git diff -w shows zero changes (no semantic edits).